### PR TITLE
Pass CSS class name to the img tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ class YourComponent extends React.Component {
 * **onClick** : function to invoke when the image is clicked
 * **disabled** : You can disable clicks
 * **style** : Style props to pass to the `img`
+* **className** : CSS class name to pass to the `img`
 
 ### Tips:
 

--- a/src/index.js
+++ b/src/index.js
@@ -32,6 +32,7 @@ class HoverImage extends React.Component {
         onMouseOver={this.mouseOver}
         onMouseOut={this.mouseOut}
         onClick={this.handleClick}
+        className={this.props.className}
       />
     )
   }


### PR DESCRIPTION
This PR adds the passing of a CSS class name to the underlying `img`. Example:

css:
```css
smallImages {
    height: 12pt;
}
```
JavaScript:
```javascript
<HoverImage src={yourFile}
    hoverSrc={yourFileHover}
    className="smallImages"
/>
